### PR TITLE
Fix dynamic Huffman RLE sequence

### DIFF
--- a/src/decode/gz_encoder.rs
+++ b/src/decode/gz_encoder.rs
@@ -205,9 +205,12 @@ impl DeflateEncoder {
             bw.write_bits(clens[CODE_LENGTH_ORDER[i]] as u32, 3);
         }
 
-        // 4) Encoded code lengths using RLE
-        rle_encode(&mut bw, &lit_lens[..hlit], &cl_codes);
-        rle_encode(&mut bw, &dist_lens[..hdist], &cl_codes);
+        // 4) Encoded code lengths using RLE over the combined sequence of
+        //    literal/length and distance lengths as required by RFC 1951.
+        let mut combined = Vec::with_capacity(hlit + hdist);
+        combined.extend_from_slice(&lit_lens[..hlit]);
+        combined.extend_from_slice(&dist_lens[..hdist]);
+        rle_encode(&mut bw, &combined, &cl_codes);
 
         // 5) Encode token stream
         for token in tokens {


### PR DESCRIPTION
## Summary
- encode code lengths in a single combined sequence when writing dynamic Huffman blocks

## Testing
- `cargo test --quiet` *(fails: Deflate self-check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6881791a60088321859b6a6d8d292abb