### PR TITLE
Implement TLS record encryption

### DIFF
--- a/src/ssl/record.rs
+++ b/src/ssl/record.rs
@@ -1,4 +1,10 @@
+use super::aes::AesCipher;
+use super::crypto::{hmac, sha256};
+
 pub type ContentType = u8;
+
+/// TLS version constant for TLS 1.2 used by the examples.
+pub const TLS_VERSION_1_2: u16 = 0x0303;
 
 #[derive(Debug)]
 pub struct RecordHeader {
@@ -28,5 +34,90 @@ impl RecordHeader {
         bytes[1..3].copy_from_slice(&self.version.to_be_bytes());
         bytes[3..5].copy_from_slice(&self.length.to_be_bytes());
         bytes
+    }
+}
+
+/// A parsed TLS record containing the header and decrypted payload.
+#[derive(Debug)]
+pub struct TlsRecord {
+    pub header: RecordHeader,
+    pub payload: Vec<u8>,
+}
+
+/// Encrypt a plaintext `payload` and build a TLS record.
+pub fn encrypt_record(
+    content_type: ContentType,
+    payload: &[u8],
+    cipher: &AesCipher,
+    mac_key: &[u8],
+    iv: &[u8; 16],
+) -> Vec<u8> {
+    let mac = hmac::hmac(sha256::hash, mac_key, payload);
+    let mut plain = Vec::with_capacity(payload.len() + mac.len());
+    plain.extend_from_slice(payload);
+    plain.extend_from_slice(&mac);
+    let encrypted = cipher.encrypt_cbc(&plain, iv);
+    let header = RecordHeader {
+        content_type,
+        version: TLS_VERSION_1_2,
+        length: encrypted.len() as u16,
+    };
+    let mut out = Vec::new();
+    out.extend_from_slice(&header.to_bytes());
+    out.extend_from_slice(&encrypted);
+    out
+}
+
+/// Decrypt a record payload and verify its MAC.
+pub fn decrypt_record(
+    header: &RecordHeader,
+    data: &[u8],
+    cipher: &AesCipher,
+    mac_key: &[u8],
+    iv: &[u8; 16],
+) -> Option<TlsRecord> {
+    let decrypted = cipher.decrypt_cbc(data, iv)?;
+    if decrypted.len() < 32 { return None; }
+    let mac_start = decrypted.len() - 32;
+    let payload = &decrypted[..mac_start];
+    let mac = &decrypted[mac_start..];
+    let expected = hmac::hmac(sha256::hash, mac_key, payload);
+    if mac != expected { return None; }
+    Some(TlsRecord { header: RecordHeader { ..*header }, payload: payload.to_vec() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ssl::aes::AesCipher;
+
+    #[test]
+    fn round_trip_encrypt_decrypt() {
+        let key = [0u8; 16];
+        let cipher = AesCipher::new_128(&key);
+        let mac_key = b"mac-key".to_vec();
+        let iv = [1u8; 16];
+        let msg = b"hello world";
+        let enc = encrypt_record(23, msg, &cipher, &mac_key, &iv);
+        let header = RecordHeader::parse(&enc[..5]).unwrap();
+        let body = &enc[5..];
+        let dec = decrypt_record(&header, body, &cipher, &mac_key, &iv).unwrap();
+        assert_eq!(dec.payload, msg);
+    }
+
+    #[test]
+    fn bad_mac_fails() {
+        let key = [0u8; 16];
+        let cipher = AesCipher::new_128(&key);
+        let mac_key = b"mac-key".to_vec();
+        let iv = [1u8; 16];
+        let msg = b"hello";
+        let mut enc = encrypt_record(22, msg, &cipher, &mac_key, &iv);
+        // Flip a byte in ciphertext
+        let last = enc.len() - 1;
+        enc[last] ^= 0x01;
+        let header = RecordHeader::parse(&enc[..5]).unwrap();
+        let body = &enc[5..];
+        assert!(decrypt_record(&header, body, &cipher, &mac_key, &iv).is_none());
     }
 }

--- a/src/ssl/state.rs
+++ b/src/ssl/state.rs
@@ -1,5 +1,10 @@
+use std::io::{Read, Write};
 use std::net::TcpStream;
 
+use super::aes::AesCipher;
+use super::record::{encrypt_record, decrypt_record, ContentType, RecordHeader, TLS_VERSION_1_2};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TlsState {
     Plain,     // No TLS, plain text communication
     Handshake, // TLS handshake in progress
@@ -11,4 +16,100 @@ pub struct TlsSession {
     stream: TcpStream,
     state: TlsState,
     buffer: Vec<u8>, // Buffer for incoming data
+    cipher: Option<AesCipher>,
+    mac_key: Vec<u8>,
+    iv: [u8; 16],
+}
+
+impl TlsSession {
+    /// Create a new `TlsSession` in plaintext mode.
+    pub fn new(stream: TcpStream) -> Self {
+        TlsSession {
+            stream,
+            state: TlsState::Plain,
+            buffer: Vec::new(),
+            cipher: None,
+            mac_key: Vec::new(),
+            iv: [0u8; 16],
+        }
+    }
+
+    /// Enable encrypted mode using the provided cipher, MAC key and IV.
+    pub fn enable_encryption(&mut self, cipher: AesCipher, mac_key: Vec<u8>, iv: [u8; 16]) {
+        self.cipher = Some(cipher);
+        self.mac_key = mac_key;
+        self.iv = iv;
+        self.state = TlsState::Encrypted;
+    }
+
+    /// Send a TLS record with the given `content_type` and `payload`.
+    pub fn send(&mut self, content_type: ContentType, payload: &[u8]) -> std::io::Result<()> {
+        let data = if self.state == TlsState::Encrypted {
+            let cipher = self.cipher.as_ref().expect("cipher not set");
+            encrypt_record(content_type, payload, cipher, &self.mac_key, &self.iv)
+        } else {
+            let header = RecordHeader {
+                content_type,
+                version: TLS_VERSION_1_2,
+                length: payload.len() as u16,
+            };
+            let mut out = Vec::new();
+            out.extend_from_slice(&header.to_bytes());
+            out.extend_from_slice(payload);
+            out
+        };
+        self.stream.write_all(&data)
+    }
+
+    /// Receive the next TLS record from the stream.
+    pub fn recv(&mut self) -> std::io::Result<(ContentType, Vec<u8>)> {
+        let mut header_buf = [0u8; 5];
+        self.stream.read_exact(&mut header_buf)?;
+        let header = RecordHeader::parse(&header_buf).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid header"))?;
+        let mut payload = vec![0u8; header.length as usize];
+        self.stream.read_exact(&mut payload)?;
+        if self.state == TlsState::Encrypted {
+            let cipher = self.cipher.as_ref().expect("cipher not set");
+            let record = decrypt_record(&header, &payload, cipher, &self.mac_key, &self.iv)
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "MAC check failed"))?;
+            Ok((record.header.content_type, record.payload))
+        } else {
+            Ok((header.content_type, payload))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+
+    #[test]
+    fn session_send_recv_encrypted() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let handle = thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            let mut server = TlsSession::new(socket);
+            let cipher = AesCipher::new_128(&[0u8; 16]);
+            server.enable_encryption(cipher, b"mac-key".to_vec(), [1u8; 16]);
+            let (ct, data) = server.recv().unwrap();
+            assert_eq!(ct, 23);
+            assert_eq!(data, b"secret");
+            server.send(23, b"ack").unwrap();
+        });
+
+        let client_socket = TcpStream::connect(addr).unwrap();
+        let mut client = TlsSession::new(client_socket);
+        let cipher = AesCipher::new_128(&[0u8; 16]);
+        client.enable_encryption(cipher, b"mac-key".to_vec(), [1u8; 16]);
+        client.send(23, b"secret").unwrap();
+        let (ct, resp) = client.recv().unwrap();
+        assert_eq!(ct, 23);
+        assert_eq!(resp, b"ack");
+
+        handle.join().unwrap();
+    }
 }


### PR DESCRIPTION
## Summary
- support AES and HMAC when sending or receiving TLS records
- add a basic TLS session that can encrypt/decrypt records
- test TLS record round trips and session behavior

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6883c91103e08321b7d4a6fe8e003f53