### PR TITLE
Implement certificate chain verification

### DIFF
--- a/src/ssl/x509.rs
+++ b/src/ssl/x509.rs
@@ -1,4 +1,6 @@
 use std::io::{Cursor, Read};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 use crate::ssl::bigint::BigUint;
 use crate::ssl::crypto::sha256;
 
@@ -46,6 +48,11 @@ pub struct X509Certificate {
     pub exponent: BigUint,       // RSA public exponent e
     pub sig_alg_outer: String,
     pub signature: Vec<u8>,
+}
+
+/// A chain of certificates as sent in a TLS Certificate message
+pub struct CertificateChain {
+    pub certificates: Vec<X509Certificate>,
 }
 
 impl<R: Read> DerReader<R> {
@@ -287,6 +294,131 @@ impl X509Certificate {
         if oct.tag != 0x04 { return Err("Expected OCTET STRING".into()); }
         Ok(oct.value == digest)
     }
+
+    /// Verify this certificate's signature using the issuer's public key
+    pub fn verify_with(&self, issuer: &X509Certificate) -> Result<bool, String> {
+        if self.issuer != issuer.subject {
+            return Err("Issuer mismatch".into());
+        }
+        if self.sig_alg_inner != "1.2.840.113549.1.1.11" {
+            return Err(format!("Unsupported sigalg: {}", self.sig_alg_inner));
+        }
+        let digest = sha256::hash(&self.tbs);
+        let sig_int = BigUint::from_bytes_be(&self.signature);
+        let m_int = sig_int.modpow(&issuer.exponent, &issuer.modulus);
+
+        let k = issuer.modulus.to_bytes_be().len();
+        let mut em = m_int.to_bytes_be();
+        if em.len() < k {
+            let mut padded = vec![0u8; k - em.len()];
+            padded.extend_from_slice(&em);
+            em = padded;
+        }
+
+        let mut i = 0;
+        if em[i] == 0 { i += 1; }
+        if em.get(i) != Some(&0x01) { return Err("Invalid padding".into()); }
+        i += 1;
+        while i < em.len() && em[i] == 0xFF { i += 1; }
+        if i >= em.len() || em[i] != 0x00 { return Err("Invalid padding".into()); }
+        i += 1;
+
+        let mut rdr = DerReader::new(Cursor::new(&em[i..]));
+        let seq = rdr.read_object().map_err(|e| e.to_string())?;
+        let mut inner = DerReader::new(Cursor::new(&seq.value));
+        let _ = inner.read_object().map_err(|e| e.to_string())?;
+        let oct = inner.read_object().map_err(|e| e.to_string())?;
+        if oct.tag != 0x04 { return Err("Expected OCTET STRING".into()); }
+        Ok(oct.value == digest)
+    }
+
+    /// Parse the common name from the subject field
+    fn subject_cn(&self) -> Option<String> {
+        let mut rdr = DerReader::new(Cursor::new(&self.subject));
+        let seq = rdr.read_object().ok()?;
+        if seq.tag != 0x30 { return None; }
+        let mut sr = DerReader::new(Cursor::new(&seq.value));
+        while let Ok(set) = sr.read_object() {
+            let mut set_rdr = DerReader::new(Cursor::new(&set.value));
+            if let Ok(attr_seq) = set_rdr.read_object() {
+                let mut ar = DerReader::new(Cursor::new(&attr_seq.value));
+                let oid = ar.read_object().ok()?;
+                if decode_oid(&oid.value) == "2.5.4.3" {
+                    if let Ok(cn_obj) = ar.read_object() {
+                        return Some(String::from_utf8_lossy(&cn_obj.value).into_owned());
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Extract DNS names from the Subject Alternative Name extension
+    fn subject_alt_names(&self) -> Vec<String> {
+        let mut names = Vec::new();
+        let mut rdr = DerReader::new(Cursor::new(&self.tbs));
+        let seq = match rdr.read_object() {
+            Ok(o) => o,
+            Err(_) => return names,
+        };
+        let mut tr = DerReader::new(Cursor::new(&seq.value));
+
+        // Skip until after SubjectPublicKeyInfo
+        let first = match tr.read_object() { Ok(o) => o, Err(_) => return names };
+        if first.tag == 0xA0 { if tr.read_object().is_err() { return names; } }
+        for _ in 0..5 { if tr.read_object().is_err() { return names; } }
+        if let Ok(obj) = tr.read_object() {
+            if obj.tag == 0xA3 {
+                let mut ext_rdr = DerReader::new(Cursor::new(&obj.value));
+                if let Ok(ext_seq) = ext_rdr.read_object() {
+                    let mut es = DerReader::new(Cursor::new(&ext_seq.value));
+                    while let Ok(ext) = es.read_object() {
+                        let mut er = DerReader::new(Cursor::new(&ext.value));
+                        let oid = match er.read_object() { Ok(o) => o, Err(_) => return names };
+                        let oid_str = decode_oid(&oid.value);
+                        let val_obj = match er.read_object() {
+                            Ok(o) if o.tag == 0x01 => match er.read_object() { Ok(v) => v, Err(_) => return names },
+                            Ok(o) => o,
+                            Err(_) => return names,
+                        };
+                        if oid_str == "2.5.29.17" {
+                            let mut val_rdr = DerReader::new(Cursor::new(&val_obj.value));
+                            if let Ok(gn_seq) = val_rdr.read_object() {
+                                let mut gn_rdr = DerReader::new(Cursor::new(&gn_seq.value));
+                                while let Ok(name) = gn_rdr.read_object() {
+                                    if name.tag == 0x82 { // dNSName [2]
+                                        names.push(String::from_utf8_lossy(&name.value).into_owned());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        names
+    }
+
+    /// Check if the certificate is valid at `time`
+    pub fn is_valid_at(&self, time: SystemTime) -> bool {
+        let nb = parse_time(&self.not_before);
+        let na = parse_time(&self.not_after);
+        match (nb, na) {
+            (Some(nb), Some(na)) => time >= nb && time <= na,
+            _ => false,
+        }
+    }
+
+    /// Check if certificate matches the given hostname
+    pub fn matches_hostname(&self, host: &str) -> bool {
+        for name in self.subject_alt_names() {
+            if dns_matches(host, &name) { return true; }
+        }
+        if let Some(cn) = self.subject_cn() {
+            if dns_matches(host, &cn) { return true; }
+        }
+        false
+    }
 }
 
 /// Parse OID sequence
@@ -321,6 +453,96 @@ fn decode_oid(bytes: &[u8]) -> String {
     nodes.join(".")
 }
 
+/// Convert ASN.1 time string into SystemTime
+fn parse_time(s: &str) -> Option<SystemTime> {
+    if !s.ends_with('Z') { return None; }
+    let bytes = s.as_bytes();
+    match bytes.len() {
+        13 => { // UTCTime YYMMDDHHMMSSZ
+            let year = std::str::from_utf8(&bytes[0..2]).ok()?.parse::<i32>().ok()?;
+            let year = if year < 50 { 2000 + year } else { 1900 + year };
+            parse_components(year, &bytes[2..])
+        }
+        15 => { // GeneralizedTime YYYYMMDDHHMMSSZ
+            let year = std::str::from_utf8(&bytes[0..4]).ok()?.parse::<i32>().ok()?;
+            parse_components(year, &bytes[4..])
+        }
+        _ => None,
+    }
+}
+
+fn parse_components(year: i32, rest: &[u8]) -> Option<SystemTime> {
+    let month = std::str::from_utf8(&rest[0..2]).ok()?.parse::<u32>().ok()?;
+    let day = std::str::from_utf8(&rest[2..4]).ok()?.parse::<u32>().ok()?;
+    let hour = std::str::from_utf8(&rest[4..6]).ok()?.parse::<u32>().ok()?;
+    let min = std::str::from_utf8(&rest[6..8]).ok()?.parse::<u32>().ok()?;
+    let sec = std::str::from_utf8(&rest[8..10]).ok()?.parse::<u32>().ok()?;
+    let days = days_from_civil(year, month, day)?;
+    let secs = days * 86400 + (hour as i64) * 3600 + (min as i64) * 60 + sec as i64;
+    if secs < 0 { None } else { Some(UNIX_EPOCH + Duration::from_secs(secs as u64)) }
+}
+
+fn days_from_civil(y: i32, m: u32, d: u32) -> Option<i64> {
+    if m < 1 || m > 12 || d == 0 || d > 31 { return None; }
+    let y = y - (m <= 2) as i32;
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (m as i32 + if m > 2 { -3 } else { 9 }) + 2) / 5 + d as i32 - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    Some((era * 146097 + doe - 719468) as i64)
+}
+
+fn dns_matches(host: &str, pattern: &str) -> bool {
+    if pattern.starts_with("*.") {
+        let suffix = &pattern[2..].to_ascii_lowercase();
+        if let Some(pos) = host.find('.') {
+            return host[pos+1..].eq_ignore_ascii_case(suffix);
+        }
+        false
+    } else {
+        host.eq_ignore_ascii_case(pattern)
+    }
+}
+
+impl CertificateChain {
+    /// Parse certificate chain from TLS Certificate message payload
+    pub fn parse(data: &[u8]) -> std::io::Result<Self> {
+        if data.len() < 3 { return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "truncated")); }
+        let total_len = ((data[0] as usize) << 16) | ((data[1] as usize) << 8) | (data[2] as usize);
+        if total_len + 3 != data.len() { return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "bad length")); }
+        let mut idx = 3;
+        let mut certs = Vec::new();
+        while idx < data.len() {
+            if idx + 3 > data.len() { return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "truncated")); }
+            let len = ((data[idx] as usize) << 16) | ((data[idx+1] as usize) << 8) | (data[idx+2] as usize);
+            idx += 3;
+            if idx + len > data.len() { return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "truncated")); }
+            let cert = X509Certificate::parse(&data[idx..idx+len])?;
+            certs.push(cert);
+            idx += len;
+        }
+        Ok(CertificateChain { certificates: certs })
+    }
+
+    /// Verify the chain and hostname
+    pub fn verify(&self, hostname: &str) -> Result<(), String> {
+        if self.certificates.is_empty() { return Err("empty chain".into()); }
+        let now = SystemTime::now();
+        for cert in &self.certificates {
+            if !cert.is_valid_at(now) { return Err("certificate expired".into()); }
+        }
+        for i in 0..self.certificates.len()-1 {
+            let cert = &self.certificates[i];
+            let issuer = &self.certificates[i+1];
+            if !cert.verify_with(issuer)? { return Err("signature check failed".into()); }
+        }
+        if !self.certificates[0].matches_hostname(hostname) {
+            return Err("hostname mismatch".into());
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -351,5 +573,22 @@ mod tests {
         assert!(!cert.subject.is_empty(), "Subject should not be empty");
         assert!(!cert.pubkey.is_empty(), "Public key should not be empty");
         assert!(!cert.signature.is_empty(), "Signature should not be empty");
+    }
+
+    #[test]
+    fn test_certificate_chain_verify() {
+        let der = include_bytes!("../../tests/test.cer");
+        // Build TLS certificate message payload with single certificate
+        let mut chain = Vec::new();
+        chain.extend_from_slice(&((der.len() as u32).to_be_bytes()[1..]));
+        chain.extend_from_slice(der);
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&((chain.len() as u32).to_be_bytes()[1..]));
+        payload.extend_from_slice(&chain);
+        let chain = CertificateChain::parse(&payload).expect("parse chain");
+        assert_eq!(chain.certificates.len(), 1);
+        chain.verify("localhost").expect("verify chain");
+        assert!(chain.certificates[0].matches_hostname("myapp.local"));
+        assert!(!chain.certificates[0].matches_hostname("example.com"));
     }
 }


### PR DESCRIPTION
## Summary
- extend x509 certificate parser with chain support
- verify signatures against issuer and validate time period
- implement hostname verification
- add tests for certificate chain parsing

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6883d3022b608321a126bd8155a54ee4