### PR TITLE
Improve TLS handshake

### DIFF
--- a/src/http/v11/http_v11.rs
+++ b/src/http/v11/http_v11.rs
@@ -714,9 +714,9 @@ fn create_client(
     tcp_stream: TcpStream,
     tls: Option<TlsConfig>,
 ) -> Result<Arc<Mutex<HttpV11ServerClient>>, String> {
-    if let Some(_cfg) = tls {
+    if let Some(cfg) = tls {
         let mut session = TlsSession::new(tcp_stream);
-        server_handshake(&mut session).map_err(|e| e.to_string())?;
+        server_handshake(&mut session, &cfg.cert).map_err(|e| e.to_string())?;
         let addr = session.local_addr().unwrap();
         let client = Arc::new(Mutex::new(HttpV11ServerClient::new_tls(
             addr.ip(),


### PR DESCRIPTION
## Summary
- implement standard TLS handshake messages like Certificate, ServerHelloDone and ChangeCipherSpec
- update server handshake to accept certificate bytes
- pass certificate from HTTP server when establishing TLS

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6883e750b6f083219c3962b97c064a2d