### PR TITLE
Fix TLS server key exchange serialization

### DIFF
--- a/src/ssl/handshake.rs
+++ b/src/ssl/handshake.rs
@@ -247,6 +247,10 @@ impl ServerKeyExchangeDH {
         out.extend_from_slice(&self.g);
         out.extend_from_slice(&(self.public_key.len() as u16).to_be_bytes());
         out.extend_from_slice(&self.public_key);
+        if !self.signature.is_empty() {
+            out.extend_from_slice(&(self.signature.len() as u16).to_be_bytes());
+            out.extend_from_slice(&self.signature);
+        }
         out
     }
 


### PR DESCRIPTION
## Summary
- include the signature in `ServerKeyExchangeDH::to_bytes`
- all tests pass

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68841cf7d35c83219aa1c55b3cb2a38d