### PR TITLE
Implement TLS cipher negotiation

### DIFF
--- a/src/http/v11/http_v11.rs
+++ b/src/http/v11/http_v11.rs
@@ -766,7 +766,7 @@ fn create_client(
 ) -> Result<Arc<Mutex<HttpV11ServerClient>>, String> {
     if let Some(cfg) = tls {
         let mut session = TlsSession::new(tcp_stream);
-        server_handshake(&mut session, &cfg.cert, &cfg.key).map_err(|e| e.to_string())?;
+        server_handshake(&mut session, &cfg).map_err(|e| e.to_string())?;
         let addr = session.local_addr().unwrap();
         let client = Arc::new(Mutex::new(HttpV11ServerClient::new_tls(
             addr.ip(),


### PR DESCRIPTION
## Summary
- introduce `cipher_name_to_code` and add cipher negotiation in `server_handshake`
- support picking ciphers from `TlsConfig`
- adjust HTTP server and tests for new API
- support all available ciphers via `SUPPORTED_CIPHER_SUITES`

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68843954929c832184690e0b7c7a783f