### PR TITLE
Add trusted root verification to X509 chain

### DIFF
--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -9,4 +9,4 @@ mod record;
 mod rng;
 pub mod rsa;
 pub mod state;
-mod x509;
+pub mod x509;


### PR DESCRIPTION
## Summary
- expose `x509` module publicly
- extend `CertificateChain::verify` to check the final cert against a list of trusted roots
- update TLS client handshake to accept trusted roots
- load the development certificate in tests and client

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6884ef54b9cc83218489e4f58cb40830