### PR TITLE
Enforce DH parameter validation

### DIFF
--- a/src/ssl/dh.rs
+++ b/src/ssl/dh.rs
@@ -72,7 +72,9 @@ impl DiffieHellman {
 }
 
 /// Probabilistic primality test using a small set of Miller-Rabin witnesses.
-fn is_prime(candidate: &BigUint) -> bool {
+/// Probabilistic Miller-Rabin primality test.
+/// Exposed for verifying received Diffie-Hellman parameters.
+pub fn is_prime(candidate: &BigUint) -> bool {
     use std::cmp::Ordering;
 
     // handle small primes explicitly
@@ -119,6 +121,20 @@ fn is_prime(candidate: &BigUint) -> bool {
         }
     }
     true
+}
+
+/// Check that `val` is in the inclusive range [2, p-2].
+pub fn in_range_2_to_p_minus_2(val: &BigUint, p: &BigUint) -> bool {
+    use std::cmp::Ordering;
+    let two = BigUint::from_bytes_be(&[2]);
+    if val.cmp(&two) == Ordering::Less {
+        return false;
+    }
+    if p.cmp(&two) != Ordering::Greater {
+        return false;
+    }
+    let max = p.sub(&two);
+    val.cmp(&max) != Ordering::Greater
 }
 
 fn to_u64(n: &BigUint) -> u64 {


### PR DESCRIPTION
## Summary
- expose `is_prime` and add helper to check DH value range
- validate Diffie-Hellman parameters in `client_handshake`
- validate client public key in `server_handshake`
- add unit tests for invalid parameters

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688514c0925c832184a36d7add8dd552