### PR TITLE
Simplify BigUint mod operations

### DIFF
--- a/src/ssl/bigint.rs
+++ b/src/ssl/bigint.rs
@@ -131,104 +131,6 @@ fn karatsuba_mul(a: &[u32], b: &[u32]) -> Vec<u32> {
     trim_be(res)
 }
 
-fn modinv32(x: u32) -> u32 {
-    let mut t: i64 = 0;
-    let mut new_t: i64 = 1;
-    let mut r: i64 = 1i64 << 32;
-    let mut new_r: i64 = x as i64;
-
-    while new_r != 0 {
-        let q = r / new_r;
-        let temp_t = t - q * new_t;
-        t = new_t;
-        new_t = temp_t;
-        let temp_r = r - q * new_r;
-        r = new_r;
-        new_r = temp_r;
-    }
-
-    if r > 1 {
-        panic!("inverse does not exist");
-    }
-    if t < 0 {
-        t += 1i64 << 32;
-    }
-    t as u32
-}
-
-fn to_le(x: &BigUint, n: usize) -> Vec<u32> {
-    let mut out = vec![0u32; n];
-    let len = x.0.len();
-    for i in 0..n {
-        if i < len {
-            out[i] = x.0[len - 1 - i];
-        }
-    }
-    out
-}
-
-fn from_le(v: &[u32]) -> BigUint {
-    let mut be = v.to_vec();
-    be.reverse();
-    BigUint::new(be)
-}
-
-fn montgomery_mul(a: &BigUint, b: &BigUint, m: &BigUint, m0inv: u32) -> BigUint {
-    let n = m.0.len();
-    let al = to_le(a, n);
-    let bl = to_le(b, n);
-    let ml = to_le(m, n);
-    let mut t = vec![0u64; n + 1];
-
-    for i in 0..n {
-        // t += a[i] * b
-        let mut carry = 0u64;
-        for j in 0..n {
-            let idx = j;
-            let tmp = t[idx]
-                + al[i] as u64 * bl[j] as u64
-                + carry;
-            t[idx] = tmp & 0xFFFF_FFFF;
-            carry = tmp >> 32;
-        }
-        t[n] = t[n].wrapping_add(carry);
-
-        // q = t[0] * m0inv mod base
-        let q = ((t[0] as u32).wrapping_mul(m0inv)) as u64 & 0xFFFF_FFFF;
-
-        // t += q * m
-        carry = 0u64;
-        for j in 0..n {
-            let idx = j;
-            let tmp = t[idx]
-                + q * ml[j] as u64
-                + carry;
-            t[idx] = tmp & 0xFFFF_FFFF;
-            carry = tmp >> 32;
-        }
-        t[n] = t[n].wrapping_add(carry);
-
-        // divide by base (shift right one limb)
-        for k in 0..n {
-            t[k] = t[k + 1];
-        }
-        t[n] = 0;
-    }
-
-    let mut res_le = vec![0u32; n];
-    for i in 0..n {
-        res_le[i] = t[i] as u32;
-    }
-    let mut res = from_le(&res_le);
-    if res.cmp(m) != Ordering::Less {
-        res = res.sub(m);
-    }
-    res
-}
-
-fn montgomery_reduce(x: &BigUint, m: &BigUint, m0inv: u32) -> BigUint {
-    montgomery_mul(x, &BigUint::one(), m, m0inv)
-}
 
 impl BigUint {
     /// Create a new BigUint trimming leading zeros.
@@ -437,48 +339,34 @@ impl BigUint {
         prod.rem(m)
     }
 
-    /// Compute (self * other) mod m using Montgomery multiplication.
+    /// Compute (self * other) mod m using a basic schoolbook approach.
     pub fn mul_mod_montgomery(&self, other: &BigUint, m: &BigUint) -> BigUint {
-        assert!(m.0.last().unwrap() % 2 == 1, "modulus must be odd");
-        let n = m.0.len();
-        let inv = modinv32(*m.0.last().unwrap());
-        let m0inv = (0u32).wrapping_sub(inv);
-
-        let mut r_limbs = vec![0u32; n + 1];
-        r_limbs[0] = 1;
-        let r = BigUint::new(r_limbs);
-        let r2 = r.mul(&r).rem(m);
-
-        let a_m = montgomery_mul(&self.rem(m), &r2, m, m0inv);
-        let b_m = montgomery_mul(&other.rem(m), &r2, m, m0inv);
-        let prod = montgomery_mul(&a_m, &b_m, m, m0inv);
-        montgomery_reduce(&prod, m, m0inv)
+        // Montgomery multiplication previously used for performance.  The
+        // simplified implementation below relies on the existing `mul_mod`
+        // method which performs a full multiplication followed by a modulus
+        // reduction using long division.
+        self.mul_mod(other, m)
     }
 
     /// Modular exponentiation: self^exp mod m.
     pub fn modpow(&self, exp: &BigUint, m: &BigUint) -> BigUint {
         assert!(m.0.last().unwrap() % 2 == 1, "modulus must be odd");
-        let n = m.0.len();
-        let inv = modinv32(*m.0.last().unwrap());
-        let m0inv = (0u32).wrapping_sub(inv);
 
-        let mut r_limbs = vec![0u32; n + 1];
-        r_limbs[0] = 1;
-        let r = BigUint::new(r_limbs);
-        let r_mod = r.rem(m);
-        let r2 = r_mod.mul_mod(&r_mod, m);
-
-        let mut result = montgomery_mul(&BigUint::one(), &r2, m, m0inv);
-        let base = montgomery_mul(&self.rem(m), &r2, m, m0inv);
+        // Classic square-and-multiply algorithm using the schoolbook
+        // multiplication routine.  The exponent is scanned from most
+        // significant bit to least significant bit to match the original
+        // implementation.
+        let mut result = BigUint::one();
+        let base = self.rem(m);
         for &digit in exp.0.iter() {
             for i in (0..32).rev() {
-                result = montgomery_mul(&result, &result, m, m0inv);
+                result = result.mul_mod(&result, m);
                 if (digit >> i) & 1 == 1 {
-                    result = montgomery_mul(&result, &base, m, m0inv);
+                    result = result.mul_mod(&base, m);
                 }
             }
         }
-        montgomery_reduce(&result, m, m0inv)
+        result
     }
 
     /// Divide by a small integer, returning (quotient, remainder).


### PR DESCRIPTION
## Summary
- remove Montgomery helper routines in BigUint
- reimplement `mul_mod_montgomery` as a thin wrapper over `mul_mod`
- rewrite `modpow` to use schoolbook multiplication
- compile tests

## Testing
- `cargo test --no-run --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6886a159330083218e90f45c6cc5f2d2