### PR TITLE
Add slow TLS tests feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ hmac = "0.12"
 hex = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
+
+[features]
+slow-tests = []

--- a/src/http/v11/http_v11.rs
+++ b/src/http/v11/http_v11.rs
@@ -995,6 +995,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn https_server_connection() {
         use crate::ssl::handshake_state::client_handshake;
         use crate::ssl::state::TlsSession;
@@ -1064,6 +1066,7 @@ mod tests {
 
     #[test]
     #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn https_client_helper() {
         use std::net::{IpAddr, Ipv4Addr};
 

--- a/src/ssl/handshake_state.rs
+++ b/src/ssl/handshake_state.rs
@@ -656,6 +656,8 @@ mod tests {
     use crate::http::server::TlsConfig;
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn diffie_hellman_handshake() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -694,6 +696,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn diffie_hellman_aes256() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -731,6 +735,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn rsa_handshake() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -768,6 +774,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn rsa_sha1_handshake() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -805,6 +813,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn dhe_sha1_handshake() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -842,6 +852,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn tls_stream_roundtrip() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -881,6 +893,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn sni_certificate_selection() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -914,6 +928,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn server_handshake_requires_certificate() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -949,6 +965,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn client_fails_on_empty_certificate() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -990,6 +1008,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn client_rejects_invalid_dh_params() {
         use std::thread;
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -1062,6 +1082,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn server_rejects_invalid_client_key() {
         use std::thread;
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -1110,6 +1132,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn client_rejects_wrong_tls_version() {
         use std::thread;
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -1147,6 +1171,8 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    #[cfg(feature = "slow-tests")]
     fn server_rejects_wrong_tls_version() {
         use std::thread;
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,3 +13,13 @@ sh generate_localhost_cert.sh
 The resulting files `localhost_cert.pem` and `localhost_key.pem` will appear in
 the same folder. Both the certificate's Common Name and Subject Alternative Name
 are set to `localhost` so browsers will not warn about mismatched host names.
+
+## Running slow TLS tests
+
+Several integration tests perform full TLS handshakes and are marked with
+`#[ignore]`. They are compiled only when the `slow-tests` feature is enabled.
+Run them with:
+
+```sh
+cargo test --features slow-tests -- --ignored
+```

--- a/tests/openssl_tls.rs
+++ b/tests/openssl_tls.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "slow-tests")]
+
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr};
 use std::process::{Command, Stdio};
@@ -31,6 +33,7 @@ impl HttpMapping for HelloMapping {
 }
 
 #[test]
+#[ignore]
 fn openssl_https_request() {
     // Bind to port 0 to obtain an available port
     let temp = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();


### PR DESCRIPTION
## Summary
- add a `slow-tests` Cargo feature
- mark TLS handshake tests with `#[ignore]` and compile them only when the feature is enabled
- update integration tests for the new feature
- document how to run slow tests in `tests/README.md`

## Testing
- `cargo test`
- `cargo test --features slow-tests -- --ignored`


------
https://chatgpt.com/codex/tasks/task_e_68878f81f9ec83218438406fd735cd46